### PR TITLE
fix(health): adds float conversion

### DIFF
--- a/health_to_fitbit.py
+++ b/health_to_fitbit.py
@@ -88,7 +88,7 @@ for record in export_root.findall('Record'):
 
 	if(record.get('type') == "HKQuantityTypeIdentifierFlightsClimbed"):
 		if date_string in floors_dict:
-			floors_dict[date_string] = int(floors_dict[date_string]) + int(value)
+			floors_dict[date_string] = int(float(floors_dict[date_string])) + int(float(value))
 		else:
 			floors_dict[date_string] = int(float(value))
 


### PR DESCRIPTION
Hello @simonkrenger,

Firstly thanks for this handy tool! This was exactly something I was looking for, for a long time..
I encountered the error below and adding float conversion for both calculations solved my problem. 
Feel free to merge it, if you think this is the solution. 
´´´
OK. Parsing files...
Traceback (most recent call last):
  File "./health_to_fitbit.py", line 91, in <module>
    floors_dict[date_string] = int(floors_dict[date_string]) + int(value)
ValueError: invalid literal for int() with base 10: '19.5151'´
´´´